### PR TITLE
JBPM-7372 - single zip distribution for jBPM

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,6 +1,8 @@
 latestFinal:
     version: 7.7.0.Final
     releaseDate: 2018-04-04
+
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-server-7.7.0.Final-dist.zip
     jbpmBinZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-7.7.0.Final-bin.zip
     jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-7.7.0.Final-examples.zip
     jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-installer-7.7.0.Final.zip
@@ -17,6 +19,7 @@ latest:
     version: 7.7.0.Final
     releaseDate: 2018-04-04
 
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-server-7.7.0.Final-dist.zip
     jbpmBinZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-7.7.0.Final-bin.zip
     jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-7.7.0.Final-examples.zip
     jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.7.0.Final/jbpm-installer-7.7.0.Final.zip

--- a/download/download.adoc
+++ b/download/download.adoc
@@ -5,6 +5,27 @@
 
 == Latest Final version: #{site.pom.latestFinal.version}
 
+The jBPM Server distribution is the easiest way to start with jBPM. It includes:
+
+* WildFly server
+* jBPM console
+* KIE Server
+* jBPM Case management showcase app
+* jBPM Service repository (with community work items)
+
+all configured to work smoothly together.
+
+* image:download.png[] #{site.pom.latestFinal.jbpmServerZip}[Download jBPM #{site.pom.latestFinal.version} server (single zip) distribution]
+
+Just download, unzip and run
+
+[source,bash]
+----
+ curl #{site.pom.latestFinal.jbpmServerZip} --output jbpm-server-distribuion.zip
+ unzip jbpm-server-distribuion.zip -d jbpm-server
+ jbpm-server/bin/standalone.sh
+----
+
 The jBPM binaries include documentation, examples and sources.
 
 * image:download.png[] Download jBPM #{site.pom.latestFinal.version} binaries


### PR DESCRIPTION
website update to include single zip distribution on downloads page

depends on 
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/767
https://github.com/kiegroup/kie-wb-distributions/pull/771

it should only be published when the 7.8 is released and thus the zip is copied to filemgmt server

<img width="1379" alt="screen shot 2018-06-15 at 13 58 35" src="https://user-images.githubusercontent.com/904474/41466958-c3eed230-70a4-11e8-8092-bf29e2bdc962.png">
