### PR TITLE
docker image tags are not according to the last version. It is still …

### DIFF
--- a/download/download.html.haml
+++ b/download/download.html.haml
@@ -113,8 +113,10 @@ title: Download jBPM
     :asciidoc
       === http://www.docker.com/[Docker] images
 
-      You can find the Docker images for jBPM and how to use them for last final version #{site.pom.latestFinal.version} at
-
+      / Commenting because docker tags is not according to last version of the project
+      / You can find the Docker images for jBPM and how to use them for last final version #{site.pom.latestFinal.version} at
+      You can find the Docker images for jBPM and how to use them for final version 7.18.0 at
+      
       * https://hub.docker.com/r/jboss/jbpm-server-full/[jBPM Server Full]
       * https://hub.docker.com/r/jboss/jbpm-workbench/[jBPM Workbench]
       * https://hub.docker.com/r/jboss/jbpm-workbench-showcase/[jBPM Workbench Showcase]


### PR DESCRIPTION
…on 7.18.0. 

and this page will need updates when the latest image tag is out since the Workbench will now be named Business Central. So it makes sense to keep it frozen until docker image tag is out.