### PR TITLE
upgraded to 7.21.0.Final

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,39 +1,39 @@
 latestFinal:
-    version: 7.20.0.Final
-    releaseDate: 2019-04-04
+    version: 7.21.0.Final
+    releaseDate: 2019-05-07
 
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-server-7.20.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-7.20.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-7.20.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-installer-7.20.0.Final.zip
-    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-installer-full-7.20.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.20.0.Final/updatesite/
-    installerChapter: https://docs.jboss.org/jbpm/release/7.20.0.Final/jbpm-docs/html_single/#_jbpminstaller
-    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12341353
-    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.20.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-server-7.21.0.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-7.21.0.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-7.21.0.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-installer-7.21.0.Final.zip
+    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-installer-full-7.21.0.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.21.0.Final/updatesite/
+    installerChapter: https://docs.jboss.org/jbpm/release/7.21.0.Final/jbpm-docs/html_single/#_jbpminstaller
+    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12341449
+    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.21.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes
 
-    UserGuide: https://docs.jboss.org/jbpm/release/7.20.0.Final/jbpm-docs/html_single/
-    JavaDocs: https://docs.jboss.org/drools/release/7.20.0.Final/kie-api-javadoc/index.html
+    UserGuide: https://docs.jboss.org/jbpm/release/7.21.0.Final/jbpm-docs/html_single/
+    JavaDocs: https://docs.jboss.org/drools/release/7.21.0.Final/kie-api-javadoc/index.html
     Archive: https://docs.jboss.org/jbpm/
 
 latest:
-    version: 7.20.0.Final
-    releaseDate: 2019-04-04
+    version: 7.21.0.Final
+    releaseDate: 2019-05-07
 
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-server-7.20.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-7.20.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-7.20.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.20.0.Final/jbpm-installer-7.20.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.20.0.Final/updatesite/
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-server-7.21.0.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-7.21.0.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-7.21.0.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.21.0.Final/jbpm-installer-7.21.0.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.21.0.Final/updatesite/
 
-    UserGuide: https://docs.jboss.org/jbpm/release/7.20.0.Final/jbpm-docs/html_single
-    JavaDocs: https://docs.jboss.org/drools/release/7.20.0.Final/kie-api-javadoc/index.html
+    UserGuide: https://docs.jboss.org/jbpm/release/7.21.0.Final/jbpm-docs/html_single
+    JavaDocs: https://docs.jboss.org/drools/release/7.21.0.Final/kie-api-javadoc/index.html
     Nightly: https://docs.jboss.org/jbpm/release/snapshot/noPublicCI.html
 
-    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12341353
-    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.20.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes
+    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12341449
+    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.21.0.Final/jbpm-docs/html_single/#_jbpmreleasenotes
 
 nightly:
-    version: 7.20.0-SNAPSHOT
+    version: 7.22.0-SNAPSHOT
     jbpmBinaries: https://downloads.jboss.org/jbpm/release/snapshot/master/index.html
-    jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.21.0-SNAPSHOT&e=zip
+    jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.22.0-SNAPSHOT&e=zip


### PR DESCRIPTION
IMPORTANT: Please keep in mind that there are no vaild jbpm-installers on filemgmt.jboss.org.
These files have 0 bytes. The installers couldn't be built on time as we are banned from a maven2 rep. Until this doesn't work again we can't download needed artifacts. So before merging this PR please be sure that you have uploaded to filemgmt.jboss.org the right and working jbpm-installers.