### PR TITLE
removed link that points to URL not existing anymore

### DIFF
--- a/code/sourceCode.adoc
+++ b/code/sourceCode.adoc
@@ -95,12 +95,3 @@ _The source code for this website and presentations._
 
 Want to improve our sources? *Pull requests are welcome!*
 
-== Continuous integration
-:awestruct-layout: normalBase
-:showtitle:
-
-We use Jenkins for continuous integration.
-
-*Show http://ci.jbpm.org/[the Jenkins jobs].* These are mirrors of a Red Hat internal Jenkins jobs.
-
-Keep the builds green!


### PR DESCRIPTION
link removed that call an not any more existing URL: http://ci.jbpm.org/
Jenkins is behind the VPN - so not accessible publicly. This link was removed since broken links are bad for Google ranking.