### PR TITLE
upgraded to 7.48.0.Final

### DIFF
--- a/_config/importantNews.yml
+++ b/_config/importantNews.yml
@@ -9,21 +9,29 @@
 #
 # Order news by date.
 # Don't remove past news.
+- newsId: 20210113-blog
+  newsDate: 2021-01-13
+  newsTitle: Take a look at jBPM 7.48.0
+  newsContent: jBPM 7.48.0 is out, including bug fixes and exciting new features!
+  newsUrl: http://docs.jboss.org/jbpm/release/7.48.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+
 - newsId: 20201204-blog
   newsDate: 2020-12-04
   newsTitle: Take a look at jBPM 7.47.0
   newsContent: jBPM 7.47.0 is out, including bug fixes and exciting new features!
   newsUrl: http://docs.jboss.org/jbpm/release/7.47.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+
 - newsId: 20201112-blog
   newsDate: 2020-11-12
   newsTitle: Take a look at jBPM 7.46.0
   newsContent: jBPM 7.46.0 is out, including bug fixes and exciting new features!
   newsUrl: http://docs.jboss.org/jbpm/release/7.46.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
-- newsId: 20201112-blog
-  newsDate: 2020-11-12
-  newsTitle: Take a look at jBPM 7.46.0
-  newsContent: jBPM 7.46.0 is out, including bug fixes and exciting new features!
-  newsUrl: http://docs.jboss.org/jbpm/release/7.46.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+
+- newsId: 20201023-blog
+  newsDate: 2020-10-23
+  newsTitle: Take a look at jBPM 7.45.0
+  newsContent: jBPM 7.45.0 is out, including bug fixes and exciting new features!
+  newsUrl: http://docs.jboss.org/jbpm/release/7.45.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
 - newsId: 20201006-blog
   newsDate: 2020-10-06

--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,39 +1,39 @@
 latestFinal:
-    version: 7.47.0.Final
-    releaseDate: 2020-12-04
+    version: 7.48.0.Final
+    releaseDate: 2021-01-13
 
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-server-7.47.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-7.47.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-7.47.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-installer-7.47.0.Final.zip
-    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-installer-full-7.47.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.47.0.Final/updatesite/
-    installerChapter: https://docs.jboss.org/jbpm/release/7.47.0.Final/jbpm-docs/html_single/#_jbpminstaller
-    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12352151
-    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.47.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-server-7.48.0.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-7.48.0.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-7.48.0.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-installer-7.48.0.Final.zip
+    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-installer-full-7.48.0.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.48.0.Final/updatesite/
+    installerChapter: https://docs.jboss.org/jbpm/release/7.48.0.Final/jbpm-docs/html_single/#_jbpminstaller
+    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12352664
+    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.48.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
-    UserGuide: https://docs.jboss.org/jbpm/release/7.47.0.Final/jbpm-docs/html_single/
-    JavaDocs: https://docs.jboss.org/drools/release/7.47.0.Final/kie-api-javadoc/index.html
+    UserGuide: https://docs.jboss.org/jbpm/release/7.48.0.Final/jbpm-docs/html_single/
+    JavaDocs: https://docs.jboss.org/drools/release/7.48.0.Final/kie-api-javadoc/index.html
     Archive: https://docs.jboss.org/jbpm/
 
 latest:
-    version: 7.47.0.Final
-    releaseDate: 2020-12-04
+    version: 7.48.0.Final
+    releaseDate: 2021-01-13
 
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-server-7.47.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-7.47.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-7.47.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.47.0.Final/jbpm-installer-7.47.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.47.0.Final/updatesite/
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-server-7.48.0.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-7.48.0.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-7.48.0.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.48.0.Final/jbpm-installer-7.48.0.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.48.0.Final/updatesite/
 
-    UserGuide: https://docs.jboss.org/jbpm/release/7.47.0.Final/jbpm-docs/html_single
-    JavaDocs: https://docs.jboss.org/drools/release/7.47.0.Final/kie-api-javadoc/index.html
+    UserGuide: https://docs.jboss.org/jbpm/release/7.48.0.Final/jbpm-docs/html_single
+    JavaDocs: https://docs.jboss.org/drools/release/7.48.0.Final/kie-api-javadoc/index.html
     Nightly: https://docs.jboss.org/jbpm/release/snapshot/noPublicCI.html
 
-    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12352151
-    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.47.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12352664
+    whatsNewVersion: http://docs.jboss.org/jbpm/release/7.48.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
 nightly:
-    version: 7.48.0-SNAPSHOT
+    version: 7.49.0-SNAPSHOT
     jbpmBinaries: https://downloads.jboss.org/jbpm/release/snapshot/master/index.html
-    jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.48.0-SNAPSHOT&e=zip
+    jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.49.0-SNAPSHOT&e=zip


### PR DESCRIPTION
Browsing around on the web I saw that in "Latest News" from version 7.45.0.Final the jbpm-docs chapter 27. Release Notes - New and Noteworthy are pointing 
7.43.1.Final lists 7.43.0.Final
7.44.0.Final lists 7.43.0.Final
7.45.0.Final lists 7.43.0.Final
7.46.0.Final lists 7.44.0.Final
7.47.0.Final lists 7.44.0.Final
7.48.0.Final lists 7.44.0.Final

seems that in between some version updates there was nothing noteworthy?  