### PR TITLE
Add blog link

### DIFF
--- a/_layouts/base.html.haml
+++ b/_layouts/base.html.haml
@@ -59,7 +59,7 @@
         .collapse.navbar-collapse#baseNavigation
           %ul.nav.navbar-nav
             %li<
-              %a{:href => relative("/")} Home
+              %a{:href => "https://blog.kie.org/} Blog
             %li<
               %a{:href => relative("/download/download.html")} Download
             %li.dropdown


### PR DESCRIPTION
Since the logo goes home we don't need another link for it, switching it out for a link to the blog.