### PR TITLE
upgraded to 7.70.0.Final

### DIFF
--- a/_config/importantNews.yml
+++ b/_config/importantNews.yml
@@ -9,6 +9,12 @@
 #
 # Order news by date.
 # Don't remove past news.
+- newsId: 20220523-blog
+  newsDate: 2022-05-23
+  newsTitle: Take a look at jBPM 7.70.0
+  newsContent: jBPM 7.70.0 is out, including bug fixes and exciting new features!
+  newsUrl: https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+
 - newsId: 20220503-blog
   newsDate: 2022-05-03
   newsTitle: Take a look at jBPM 7.69.0

--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,39 +1,39 @@
 latestFinal:
-    version: 7.69.0.Final
-    releaseDate: 2022-05-03
+    version: 7.70.0.Final
+    releaseDate: 2022-05-23
 
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-server-7.69.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-7.69.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-7.69.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-installer-7.69.0.Final.zip
-    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-installer-full-7.69.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.69.0.Final/updatesite/
-    installerChapter: https://docs.jbpm.org/7.69.0.Final/jbpm-docs/html_single/#_jbpminstaller
-    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12384212
-    whatsNewVersion: https://docs.jbpm.org/7.69.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-server-7.70.0.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-7.70.0.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-7.70.0.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-installer-7.70.0.Final.zip
+    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-installer-full-7.70.0.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.70.0.Final/updatesite/
+    installerChapter: https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single/#_jbpminstaller
+    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12385328
+    whatsNewVersion: https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
-    UserGuide: https://docs.jbpm.org/7.69.0.Final/jbpm-docs/html_single/
-    JavaDocs: https://docs.drools.org/7.69.0.Final/kie-api-javadoc/index.html
+    UserGuide: https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single/
+    JavaDocs: https://docs.drools.org/7.70.0.Final/kie-api-javadoc/index.html
     Archive: https://docs.jbpm.org/
 
 latest:
-    version: 7.69.0.Final
-    releaseDate: 2022-05-03
+    version: 7.70.0.Final
+    releaseDate: 2022-05-23
 
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-server-7.69.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-7.69.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-7.69.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.69.0.Final/jbpm-installer-7.69.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.69.0.Final/updatesite/
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-server-7.70.0.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-7.70.0.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-7.70.0.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.70.0.Final/jbpm-installer-7.70.0.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.70.0.Final/updatesite/
 
-    UserGuide: https://docs.jbpm.org/7.69.0.Final/jbpm-docs/html_single
-    JavaDocs: https://docs.drools.org/7.69.0.Final/kie-api-javadoc/index.html
+    UserGuide: https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single
+    JavaDocs: https://docs.drools.org/7.70.0.Final/kie-api-javadoc/index.html
     Nightly: https://docs.jbpm.org/snapshot/noPublicCI.html
 
-    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12384212
-    whatsNewVersion: https://docs.jbpm.org/7.69.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12385328
+    whatsNewVersion: https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
 nightly:
-    version: 7.70.0-SNAPSHOT
+    version: 7.71.0-SNAPSHOT
     jbpmBinaries: https://downloads.jboss.org/jbpm/release/snapshot/master/index.html
-    jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.70.0-SNAPSHOT&e=zip
+    jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.71.0-SNAPSHOT&e=zip


### PR DESCRIPTION
looking at the [New and Noteworthy in jBPM 7.70.0.Final](https://docs.jbpm.org/7.70.0.Final/jbpm-docs/html_single/#jbpmreleasenotes)  I see that it is showing only until version 7.23. ? Is this OK ?