### PR TITLE
updated to 7.74.1.Final

### DIFF
--- a/data/pom.yml
+++ b/data/pom.yml
@@ -1,28 +1,28 @@
 latestFinal:
-    jbpmServerZip: https://download.jboss.org/jbpm/release/7.74.0.Final/jbpm-server-7.74.0.Final-dist.zip
-    jbpmBinZip: https://download.jboss.org/jbpm/release/7.74.0.Final/jbpm-7.74.0.Final-bin.zip
-    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.74.0.Final/jbpm-7.74.0.Final-examples.zip
-    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.74.0.Final/jbpm-installer-7.74.0.Final.zip
-    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.74.0.Final/jbpm-installer-full-7.74.0.Final.zip
-    updatesite: https://download.jboss.org/jbpm/release/7.74.0.Final/updatesite/
+    jbpmServerZip: https://download.jboss.org/jbpm/release/7.74.1.Final/jbpm-server-7.74.1.Final-dist.zip
+    jbpmBinZip: https://download.jboss.org/jbpm/release/7.74.1.Final/jbpm-7.74.1.Final-bin.zip
+    jbpmExamplesZip: https://download.jboss.org/jbpm/release/7.74.1.Final/jbpm-7.74.1.Final-examples.zip
+    jbpmInstallerZip: https://download.jboss.org/jbpm/release/7.74.1.Final/jbpm-installer-7.74.1.Final.zip
+    jbpmInstallerFullZip: https://download.jboss.org/jbpm/release/7.74.1.Final/jbpm-installer-full-7.74.1.Final.zip
+    updatesite: https://download.jboss.org/jbpm/release/7.74.1.Final/updatesite/
     releaseNotesVersion: https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12391775
-    whatsNewVersion: https://docs.jbpm.org/7.74.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    whatsNewVersion: https://docs.jbpm.org/7.74.1.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
-    UserGuide: https://docs.jbpm.org/7.74.0.Final/jbpm-docs/html_single/
+    UserGuide: https://docs.jbpm.org/7.74.1.Final/jbpm-docs/html_single/
     Archive: https://docs.jbpm.org/
 
-    version: 7.74.0.Final
-    releaseDate: 2023-06-29
+    version: 7.74.1.Final
+    releaseDate: 2023-07-20
 
-    jbpmWhatsNew: https://docs.jbpm.org/7.74.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
-    jbpmReleaseNotes: https://docs.jbpm.org/7.74.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    jbpmWhatsNew: https://docs.jbpm.org/7.74.1.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    jbpmReleaseNotes: https://docs.jbpm.org/7.74.1.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
 # latest.version can be equal to latestFinal.version
 latest:
-    version: 7.74.0.Final
-    releaseDate: 2023-06-29
+    version: 7.74.1.Final
+    releaseDate: 2023-07-20
 
-    jbpmReleaseNotes: https://docs.jbpm.org/7.74.0.Final/jbpm-docs/html_single/#jbpmreleasenotes
+    jbpmReleaseNotes: https://docs.jbpm.org/7.74.1.Final/jbpm-docs/html_single/#jbpmreleasenotes
 
 nightly:
     jbpmDocs: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jbpm&a=jbpm-docs&v=7.75.0-SNAPSHOT&e=zip


### PR DESCRIPTION
there are two things that maybe have to be fixed:

1. the number of release notes was not changed since https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=10052&version=12410883 showed a completely empty release notes of 7.74.1.Final - so the release notes are still showing 7.74.0.Final
2. [This page](https://www.jbpm.org/learn/releases.html) shows two links
[1](https://docs.jbpm.org/7.74.0.Final/jbpm-docs/html_single/#jbpmreleasenotes) and [2](https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=10052&version=12391775)
whereas [1] the latest version shown here is jBPM 7.67 [2] will show to 12391775 - so version 7.74.0.Final 